### PR TITLE
syntax error on Lighty 1.4.33-1+nmu2 (Debian Sallie):

### DIFF
--- a/src/practical_settings/webserver.tex
+++ b/src/practical_settings/webserver.tex
@@ -85,7 +85,7 @@ See appendix \ref{cha:tools}
     ssl.use-sslv3 = "disable"
     #ssl.use-compression obsolete >= 1.4.3.1
     ssl.pemfile = "/etc/lighttpd/server.pem"
-    ssl.cipher-list = '@@@CIPHERSTRINGB@@@'
+    ssl.cipher-list = "@@@CIPHERSTRINGB@@@"
     ssl.honor-cipher-order = "enable"
     setenv.add-response-header  = ( "Strict-Transport-Security" => "max-age=31536000")
   }


### PR DESCRIPTION
(just a small bug...

" instead of ' for ssl.cipher-list works for me otherwise lighty does not start with some 'unknown aNULL' error
