### PR TITLE
TODO: Test with non-Debian-OS

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -1,4 +1,3 @@
-
 Website
 ========
 
@@ -72,6 +71,8 @@ Contents
    Only then put it to all servers and keep it rather uniformely (as much as possible)
 
 2. Test all settings 
+
+* Test especially with non-Debian-OS!
 
 * Test with more clients and other OSes than OSX / iPhone!!
 --> clients? 


### PR DESCRIPTION
Right now the configs seem to be only tested with Debian GNU/Linux. However Fedora, SUSE etc. bring different versions of OpenSSL. So they might not work there.
