### PR TITLE
Disclaimer: Replace Heise Link (en)

### DIFF
--- a/src/disclaimer.tex
+++ b/src/disclaimer.tex
@@ -30,8 +30,8 @@ from one virtual machine to another via L3 cache timing attacks.}
 This guide does not talk much about the well-known insecurities of trusting a
 public-key infrastructure (PKI)\footnote{Interested readers are referred to
 \url{https://bugzilla.mozilla.org/show_bug.cgi?id=647959} or
-\url{http://www.heise.de/security/meldung/Der-ehrliche-Achmed-bittet-um-Vertrauen-1231083.html}
-(german) which brings the problem of trusting PKIs right to the point}. Nor
+\url{http://www.h-online.com/security/news/item/Honest-Achmed-asks-for-trust-1231314.html}
+which brings the problem of trusting PKIs right to the point}. Nor
 does this text fully explain how to run your own Certificate Authority (CA). 
 
 


### PR DESCRIPTION
Replaces the link to the german homepage of heise online with the english one.

Even if **The H** is [closing down](http://www.h-online.com/open/news/item/The-H-is-closing-down-1920027.html), they state to transfer their site in an online archive.

Alternative: keep the german link and state _(link to english version below article)_ or similar.
