### PR TITLE
External links

### DIFF
--- a/src/common/style.tex
+++ b/src/common/style.tex
@@ -79,8 +79,9 @@
   breaklinks,%
   colorlinks,%
   linkcolor=darkblue,citecolor=blue,urlcolor=blue,%
-  breaklinks=true,
+  breaklinks=true,%
   unicode,%
+  pdfnewwindow=true,%
   final
 }
 \urlstyle{same}

--- a/src/common/system.tex
+++ b/src/common/system.tex
@@ -67,7 +67,7 @@
 %\usepackage{draftwatermark}
 \usepackage{gitinfo}
 \usepackage{catchfile}
-\usepackage[pdfnewwindow]{hyperref}
+\usepackage{hyperref}
 
 % for development
 \usepackage{ifdraft}


### PR DESCRIPTION
I am viewing this document with Firefox's internal pdf viewer, which results in opening all external links in the same tab as the document itself.

See https://en.wikibooks.org/wiki/LaTeX/Hyperlinks#Customization for the option `pdfnewwindow`

``` quote
define if a new window should get opened when a link leads out of the current document
```

I am not sure if one should add this option to
  `fonts/opensans/doc/fonts/opensans/opensans.tex`
too.
