### PR TITLE
Confusion: EECDH+Cipher and stated "omit ECDHE"

### DIFF
--- a/src/practical_settings/webserver.tex
+++ b/src/practical_settings/webserver.tex
@@ -30,7 +30,9 @@ Enabled modules \emph{SSL} and \emph{Headers} are required.
 
 \end{lstlisting}
 
-Note that any cipher suite starting with ECDHE can be omitted, if in doubt.
+Note that any cipher suite starting with EECDH can be omitted, if in doubt.
+(Compared to the theory section, EECDH in Apache and ECDHE in OpenSSL are
+synonyms~\footnote{https://www.mail-archive.com/openssl-dev@openssl.org/msg33405.html})
 
 \subsubsection{Additional settings}
 


### PR DESCRIPTION
EECDH and ECDHE are synonyms
  https://www.mail-archive.com/openssl-dev@openssl.org/msg33405.html
but writing "you can omit all ciphers starting with ECDHE" and only
listing ciphers starting with "EECDH" will confuse the reader.
