### PR TITLE
openssh: PermitRootLogin: no -> without-password

### DIFF
--- a/src/practical_settings/ssh.tex
+++ b/src/practical_settings/ssh.tex
@@ -8,7 +8,7 @@
 
 	Protocol 2
 	PermitEmptyPasswords no
-	PermitRootLogin no
+	PermitRootLogin no # or 'without-password' to allow SSH key based login
 	StrictModes yes
 	HostKey /etc/ssh/ssh_host_rsa_key
 	Ciphers aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes128-ctr


### PR DESCRIPTION
Disabling root login entirely instead of at least allowing SSH key
based access is impractical and doesn't really increase security much.

(And I've seen someone set it to 'yes' because they really wanted
root login but didn't know about without-password.)
