### PR TITLE
Remove curve25519-sha256@libssh.org for now

### DIFF
--- a/src/practical_settings/ssh.tex
+++ b/src/practical_settings/ssh.tex
@@ -13,7 +13,7 @@
 	HostKey /etc/ssh/ssh_host_rsa_key
 	Ciphers aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes128-ctr
 	MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-ripemd160
-	KexAlgorithms curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1
+	KexAlgorithms diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1
 \end{lstlisting}
 
 \textbf{Note:} Older Linux systems won't support SHA2. PuTTY (Windows) does not support


### PR DESCRIPTION
It did not make it in the last OpenSSH release, we will re-add it with the next release, together with chacha20-poly1305@openssh.com, ssh-ed25519, ssh-ed25519-cert-v01@openssh.com and others.

@azet it seems this change, as discussed in the mailing list, did not make it in yet (@aaronkaplan compiled the lastest version just now).
