### PR TITLE
added tested versions and harmonized references to Debian Versions

### DIFF
--- a/src/acknowledgements.tex
+++ b/src/acknowledgements.tex
@@ -7,6 +7,7 @@ We would like to express our thanks to the following reviewers and people who ha
 \begin{multicols}{2}{\parskip=0pt\centering\obeylines%
 Brown, Scott \\
 Brulebois, Cyril \\
+Dirksen-Thedens, Mathis \\
 Dulaunoy, Alexandre \\
 G\"uhring Philipp  \\
 Grigg, Ian  \\

--- a/src/practical_settings/DBs.tex
+++ b/src/practical_settings/DBs.tex
@@ -25,7 +25,7 @@ p. 129 -Req 396 and Req 397 \\
 \subsubsection{MySQL}
 
 \begin{description}
-\item[Tested with Version:] Debian 7.0 and MySQL 5.5
+\item[Tested with Version:] Debian Wheezy and MySQL 5.5
 
 \item[Settings:] \mbox{}
 
@@ -104,7 +104,7 @@ TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
 \subsubsection{PostgreSQL}
 
 \begin{description}
-\item[Tested with Version:] Debian 7.0 and PostgreSQL 9.1
+\item[Tested with Version:] Debian Wheezy and PostgreSQL 9.1
 
 \item[References:]
 

--- a/src/practical_settings/im.tex
+++ b/src/practical_settings/im.tex
@@ -18,7 +18,7 @@ The last point being out-of-scope for this section, we will only cover the first
 \paragraph{ejabberd}
 
 \begin{description}
-\item[Tested with Version:] Debian 7.0, version 2.1.10-4+deb7u1
+\item[Tested with Version:] Debian Wheezy, version 2.1.10-4+deb7u1
 
 \item[Settings:] \mbox{}
 

--- a/src/practical_settings/mailserver.tex
+++ b/src/practical_settings/mailserver.tex
@@ -54,8 +54,9 @@ mode, because the alternative is plain text transmission.
 
 \subsubsection{Tested with Version} 
 \begin{itemize}
+\item Dovecot 2.1.17, Debian Wheezy (without ``ssl\_prefer\_server\_ciphers'' setting)
 \item Dovecot 2.2
-\item 2.0.19apple1 on OS X Server 10.8.5 (without ssl\_prefer\_server\_ciphers)
+\item 2.0.19apple1 on OS X Server 10.8.5 (without ``ssl\_prefer\_server\_ciphers'' setting)
 \end{itemize}
 
 \subsubsection{Settings}
@@ -166,7 +167,11 @@ There is a working patch for all three features:
 
 \subsection{Postfix}
 
-\subsubsection{Tested with Version} Postfix 2.9.6 (Debian 7.0)
+\subsubsection{Tested with Version}
+\begin{itemize}
+\item Postfix 2.9.6, Debian Wheezy
+\end{itemize}
+
 \subsubsection{Settings}
 
 %% I (cm) consider the generation of own DH parameters to be voodoo until

--- a/src/practical_settings/vpn.tex
+++ b/src/practical_settings/vpn.tex
@@ -246,7 +246,7 @@ Please note that these settings restrict the available algorithms for
 
 \begin{itemize}
 \item OpenVPN 2.3.2 from Debian ``wheezy-backports'' linked against openssl (libssl.so.1.0.0) 
-\item OpenVPN 2.2.1 from Debian 7.0 linked against openssl
+\item OpenVPN 2.2.1 from Debian Wheezy linked against openssl
     (libssl.so.1.0.0) 
 \item OpenVPN 2.3.2 for Windows
 \end{itemize}

--- a/src/practical_settings/webserver.tex
+++ b/src/practical_settings/webserver.tex
@@ -5,7 +5,8 @@
 
 \subsubsection{Tested with Versions} 
 \begin{itemize}
-\item Apache 2.4.6 linked against OpenSSL 1.0.1e, Debian jessie
+\item Apache 2.2.22 linked against OpenSSL 1.0.1e, Debian Wheezy
+\item Apache 2.4.6 linked against OpenSSL 1.0.1e, Debian Jessie
 \end{itemize}
 
 
@@ -68,7 +69,7 @@ See appendix \ref{cha:tools}
 %%\begin{description}
 \subsubsection{Tested with Version}
 \begin{itemize}
-\item lighttpd/1.4.31-4 with OpenSSL 1.0.1e on Debian 7.0
+\item lighttpd/1.4.31-4 with OpenSSL 1.0.1e on Debian Wheezy
 \item lighttpd/1.4.33 with OpenSSL 0.9.8o on Debian Squeeze (note that TLSv1.2 does not work in openssl 0.9.8 thus not all ciphers actually work)
 \item lighttpd/1.4.28-2 with OpenSSL 0.9.8o on Debian Squeeze (note that TLSv1.2 does not work in openssl 0.9.8 thus not all ciphers actually work)
 \end{itemize}
@@ -153,8 +154,8 @@ See appendix \ref{cha:tools}
 \subsubsection{Tested with Version} 
 \begin{itemize}
 \item 1.4.4 with OpenSSL 1.0.1e on OS X Server 10.8.5
-\item 1.2.1-2.2+wheezy2 with OpenSSL 1.0.1e on Debian 7.0
-\item 1.4.4 with OpenSSL 1.0.1e on Debian 7.0
+\item 1.2.1-2.2+wheezy2 with OpenSSL 1.0.1e on Debian Wheezy
+\item 1.4.4 with OpenSSL 1.0.1e on Debian Wheezy
 \item 1.2.1-2.2~bpo60+2 with OpenSSL 0.9.8o on Debian Squeeze (note that TLSv1.2 does not work in openssl 0.9.8 thus not all ciphers actually work)
 \end{itemize}
 


### PR DESCRIPTION
- added tested versions (Dovecot 2.1.17, Apache 2.2.22)
- harmonized references to Debian Versions (Wheezy makes more sense than 7.0 or 7.3)
