### PR TITLE
more URLs converted to https

### DIFF
--- a/src/disclaimer.tex
+++ b/src/disclaimer.tex
@@ -14,7 +14,7 @@ This guide specifically does not address physical security, protecting software
 and hardware against exploits, basic IT security housekeeping, information
 assurance techniques, traffic analysis attacks, issues with key-roll over and
 key management, securing client PCs and mobile devices (theft, loss), proper
-Operations Security\footnote{\url{http://en.wikipedia.org/wiki/Operations_security}}, social
+Operations Security\footnote{\url{https://en.wikipedia.org/wiki/Operations_security}}, social
 engineering attacks, anti-tempest~\cite{Wikipedia:Tempest} attack techniques,
 protecting against different side-channel attacks (timing--, cache timing--,
 differential fault analysis, differential power analysis or power monitoring

--- a/src/links.tex
+++ b/src/links.tex
@@ -15,14 +15,14 @@
   \item Elliptic Curve Cryptography in Practice: \url{http://eprint.iacr.org/2013/734.pdf}
   \item Factoring as a Service: \url{http://crypto.2013.rump.cr.yp.to/981774ce07e51813fd4466612a78601b.pdf}
   \item Black Ops of TCP/IP 2012: \url{http://dankaminsky.com/2012/08/06/bo2012/}
-  \item SSL and the Future of Authenticity, Moxie Marlinspike - Black Hat USA 2011: \url{http://www.youtube.com/watch?v=Z7Wl2FW2TcA}
+  \item SSL and the Future of Authenticity, Moxie Marlinspike - Black Hat USA 2011: \url{https://www.youtube.com/watch?v=Z7Wl2FW2TcA}
   \item ENISA - Algorithms, Key Sizes and Parameters Report (Oct.'13) \url{http://www.enisa.europa.eu/activities/identity-and-trust/library/deliverables/algorithms-key-sizes-and-parameters-report}
   \item Diffie-Hellman Groups \url{http://ibm.co/18lslZf}
   \item Diffie-Hellman Groups standardized in RFC3526~\cite{rfc3526} \url{https://datatracker.ietf.org/doc/rfc3526/}
   \item ECC-enabled GnuPG per RFC6637~\cite{rfc6637} \url{https://code.google.com/p/gnupg-ecc}
   \item TLS Security (Survey + Lucky13 + RC4 Attack) by Kenny Paterson \url{https://www.cosic.esat.kuleuven.be/ecc2013/files/kenny.pdf}
   \item Ensuring High-Quality Randomness in Cryptographic Key Generation \url{http://arxiv.org/abs/1309.7366v1}
-  \item Wikipedia: Ciphertext Stealing \url{http://en.wikipedia.org/wiki/Ciphertext_stealing}
-  \item Wikipedia: Malleability (Cryptography) \url{http://en.wikipedia.org/wiki/Malleability_(cryptography)}
+  \item Wikipedia: Ciphertext Stealing \url{https://en.wikipedia.org/wiki/Ciphertext_stealing}
+  \item Wikipedia: Malleability (Cryptography) \url{https://en.wikipedia.org/wiki/Malleability_(cryptography)}
   \item Ritter's Crypto Glossary and Dictionary of Technical Cryptography \url{http://www.ciphersbyritter.com/GLOSSARY.HTM}
 \end{itemize*}

--- a/src/practical_settings/DBs.tex
+++ b/src/practical_settings/DBs.tex
@@ -1,5 +1,5 @@
 %%\subsection{Database Systems}
-% This list is based on : http://en.wikipedia.org/wiki/Relational_database_management_system#Market_share
+% This list is based on : https://en.wikipedia.org/wiki/Relational_database_management_system#Market_share
 
 %% ---------------------------------------------------------------------- 
 \subsection{Oracle}

--- a/src/practical_settings/vpn.tex
+++ b/src/practical_settings/vpn.tex
@@ -266,7 +266,7 @@ tls-cipher DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-SHA256:DHE-RSA-AES128-GCM-SH
 cipher AES-256-CBC
 auth SHA384
 
-# http://openvpn.net/index.php/open-source/documentation/howto.html#mitm
+# https://openvpn.net/index.php/open-source/documentation/howto.html#mitm
 remote-cert-tls server
 
 tls-remote server.example.com
@@ -289,7 +289,7 @@ The configuration shown above is compatible with all tested versions.
 
 \subsubsection{References}
 \begin{itemize*}
-  \item OpenVPN Documentation: \emph{Security Overview} \url{http://openvpn.net/index.php/open-source/documentation/security-overview.html}
+  \item OpenVPN Documentation: \emph{Security Overview} \url{https://openvpn.net/index.php/open-source/documentation/security-overview.html}
 \end{itemize*}
 
 %\subsubsection{How to test}

--- a/src/security.bib
+++ b/src/security.bib
@@ -7,7 +7,7 @@
      \hyperref{http://stackexchange.com/}{}{}{Mathematics}}
 }
 @string {I_PolarSSL =
-    {\hyperref{http://polarssl.org/}{}{}{PolarSSL}}
+    {\hyperref{https://polarssl.org/}{}{}{PolarSSL}}
 }
 @string {I_Stackexchange =
     {\hyperref{http://stackexchange.com/}{}{}{Stackexchange}
@@ -15,7 +15,7 @@
      \hyperref{http://stackexchange.com/}{}{}{Site}}
 }
 @string {I_Wikipedia =
-    {\hyperref{http://wikipedia.org/}{}{}{Wikipedia}}
+    {\hyperref{https://wikipedia.org/}{}{}{Wikipedia}}
 }
 @string {I_Wolfram =
     {\hyperref{http://mathworld.wolfram.com/}{}{}{Wolfram} 
@@ -23,13 +23,13 @@
      \hyperref{http://mathworld.wolfram.com/}{}{}{Mathworld}}
 }
 @string {J_TOMACS =
-    {\hyperref{http://tomacs.acm.org/}{}{}{ACM}
-     \hyperref{http://tomacs.acm.org/}{}{}{Transactions}
-     \hyperref{http://tomacs.acm.org/}{}{}{on}
-     \hyperref{http://tomacs.acm.org/}{}{}{Modeling}
-     \hyperref{http://tomacs.acm.org/}{}{}{and}
-     \hyperref{http://tomacs.acm.org/}{}{}{Computer}
-     \hyperref{http://tomacs.acm.org/}{}{}{Simulation}}
+    {\hyperref{https://tomacs.acm.org/}{}{}{ACM}
+     \hyperref{https://tomacs.acm.org/}{}{}{Transactions}
+     \hyperref{https://tomacs.acm.org/}{}{}{on}
+     \hyperref{https://tomacs.acm.org/}{}{}{Modeling}
+     \hyperref{https://tomacs.acm.org/}{}{}{and}
+     \hyperref{https://tomacs.acm.org/}{}{}{Computer}
+     \hyperref{https://tomacs.acm.org/}{}{}{Simulation}}
 }
 
 @inproceedings{HDWH12,
@@ -50,7 +50,7 @@
    year      = {2013},
    month     = Dec,
    type      = {Wikipedia},
-   url       = {http://en.wikipedia.org/wiki/dev/random},
+   url       = {https://en.wikipedia.org/wiki/dev/random},
    note      = {Accessed 2013-12-06},
 }
 
@@ -136,7 +136,7 @@
    year      = {2013},
    month     = Dec,
    type      = {Wikipedia},
-   url       = {http://en.wikipedia.org/wiki/Export_of_cryptography_in_the_United_States},
+   url       = {https://en.wikipedia.org/wiki/Export_of_cryptography_in_the_United_States},
    note      = {Accessed 2013-12-09},
 }
 
@@ -346,7 +346,7 @@
    year      = {2013},
    month     = Dec,
    type      = {Wikipedia},
-   url       = {http://en.wikipedia.org/wiki/TinyCA},
+   url       = {https://en.wikipedia.org/wiki/TinyCA},
    note      = {Accessed 2013-12-24},
 }
 

--- a/src/theory/PKIs.tex
+++ b/src/theory/PKIs.tex
@@ -172,7 +172,7 @@ Transparency~\cite{certtransparency}.
 % A good background on PKIs can be found in
 % \footnote{\url{https://developer.mozilla.org/en/docs/Introduction_to_Public-Key_Cryptography}}
 % \footnote{\url{http://cacr.uwaterloo.ca/hac/about/chap8.pdf}}
-% \footnote{\url{http://www.verisign.com.au/repository/tutorial/cryptography/intro1.shtml}}
+% \footnote{\url{https://www.verisign.com.au/repository/tutorial/cryptography/intro1.shtml}}
 % .
 
 % \todo{ts: Background and Configuration (EMET) of Certificate Pinning,

--- a/src/theory/RNGs.tex
+++ b/src/theory/RNGs.tex
@@ -9,7 +9,7 @@
 \begin{figure}[h]
   \centering
   \includegraphics[width=0.4\textwidth]{img/random_number.png}
-  \caption{xkcd, source: \url{http://imgs.xkcd.com/comics/random_number.png}, license: CC-BY-NC}
+  \caption{xkcd, source: \url{https://imgs.xkcd.com/comics/random_number.png}, license: CC-BY-NC}
   \label{fig:dilbertRNG}
 \end{figure}
 

--- a/src/theory/cipher_suites/forward.tex
+++ b/src/theory/cipher_suites/forward.tex
@@ -3,6 +3,6 @@ Forward Secrecy or Perfect Forward Secrecy is a property of a cipher suite
 that ensures confidentiality even if the server key has been compromised.
 Thus if traffic has been recorded it can not be decrypted even if an adversary
 has got hold of the server key
-\footnote{\url{http://en.wikipedia.org/wiki/Forward\_secrecy}}
+\footnote{\url{https://en.wikipedia.org/wiki/Forward\_secrecy}}
 \footnote{\url{https://www.eff.org/deeplinks/2013/08/pushing-perfect-forward-secrecy-important-web-privacy-protection}}
 \footnote{\url{http://news.netcraft.com/archives/2013/06/25/ssl-intercepted-today-decrypted-tomorrow.html}}.

--- a/src/tools.tex
+++ b/src/tools.tex
@@ -6,8 +6,8 @@ This section lists tools for checking the security settings.
 
 Server checks via the web
 \begin{itemize*}
-  \item \href{http://ssllabs.com}{ssllabs.com} offers a great way to check your webserver for misconfigurations. See \url{https://www.ssllabs.com/ssltest/}. Furthermore, ssllabs.com has a good best practices tutorial, which focuses on avoiding the most common mistakes in SSL.
-  \item SSL Server certificate installation issues \url{http://www.sslshopper.com/ssl-checker.html}
+  \item \href{https://ssllabs.com}{ssllabs.com} offers a great way to check your webserver for misconfigurations. See \url{https://www.ssllabs.com/ssltest/}. Furthermore, ssllabs.com has a good best practices tutorial, which focuses on avoiding the most common mistakes in SSL.
+  \item SSL Server certificate installation issues \url{https://www.sslshopper.com/ssl-checker.html}
   \item Check SPDY protocol support and basic TLS setup \url{http://spdycheck.org/}
   \item XMPP/Jabber Server check (Client-to-Server and Server-to-Server) \url{https://xmpp.net/}
   \item Luxsci SMTP TLS Checker \url{https://luxsci.com/extranet/tlschecker.html}
@@ -26,8 +26,7 @@ Browser checks
 
 Command line tools
 \begin{itemize*}
-  \item \url{http://sourceforge.net/projects/sslscan} connects to a given SSL service and shows the cipher suites that are offered.
-  \item \url{http://checktls.com} is a tool for testing arbitrary TLS services. 
+  \item \url{https://sourceforge.net/projects/sslscan} connects to a given SSL service and shows the cipher suites that are offered.
   \item \url{http://www.bolet.org/TestSSLServer/} tests for BEAST and CRIME vulnerabilities.
   \item \url{https://github.com/iSECPartners/sslyze} Fast and full-featured SSL scanner
   \item \url{http://nmap.org/} nmap security scanner

--- a/tools/android/android-sniff-cipherlist.pl
+++ b/tools/android/android-sniff-cipherlist.pl
@@ -34,7 +34,7 @@ my $outputdir = shift || die $usage;
 my $apilevel = shift || die $usage;
 
 # versions indexed by API level
-# source: http://developer.android.com/guide/topics/manifest/uses-sdk-element.html#ApiLevels
+# source: https://developer.android.com/guide/topics/manifest/uses-sdk-element.html#ApiLevels
 my %androidversion = ( 2 => '1.1',
 		       3 => '1.5',
 		       4 => '1.6',


### PR DESCRIPTION
more URLs converted to https
removed duplicate link to http://checktls.com in command-line tool section
openssl.net -> openssl.org + https
