### PR TITLE
Corrected Syntax on STS

### DIFF
--- a/src/configuration/Webservers/Apache/default-ssl
+++ b/src/configuration/Webservers/Apache/default-ssl
@@ -166,7 +166,7 @@
 	Header add Strict-Transport-Security "max-age=15768000"
 	# If you want to protect all subdomains, use the following header
 	# ALL subdomains HAVE TO support HTTPS if you use this!
-	# Strict-Transport-Security: max-age=15768000 ; includeSubDomains
+	# Strict-Transport-Security: "max-age=15768000 ; includeSubDomains"
 	SSLCipherSuite 'EDH+CAMELLIA:EDH+aRSA:EECDH+aRSA+AESGCM:EECDH+aRSA+SHA384:EECDH+aRSA+SHA256:EECDH:+CAMELLIA256:+AES256:+CAMELLIA128:+AES128:+SSLv3:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!DSS:!RC4:!SEED:!ECDSA:CAMELLIA256-SHA:AES256-SHA:CAMELLIA128-SHA:AES128-SHA'
 
 </VirtualHost>


### PR DESCRIPTION
Syntax was missing "" for STS including subdomains. 
Tested with Apache 2.2.22 against OpenSSL 1.0.1e, Debian Wheezy
