### PR TITLE
Wrong verb for HSTS header

### DIFF
--- a/src/configuration/Webservers/Apache/default-ssl
+++ b/src/configuration/Webservers/Apache/default-ssl
@@ -163,7 +163,7 @@
 	SSLHonorCipherOrder On
 	SSLCompression off
 	# Add six earth month HSTS header for all users...
-	Header add Strict-Transport-Security "max-age=15768000"
+	Header set Strict-Transport-Security "max-age=15768000"
 	# If you want to protect all subdomains, use the following header
 	# ALL subdomains HAVE TO support HTTPS if you use this!
 	# Strict-Transport-Security: "max-age=15768000 ; includeSubDomains"


### PR DESCRIPTION
`Header add` will always add the header, even if it already exists. `Header set` should be used if we want to enforce it server wide or `Header setifempty` if we want to allow users on the server to override the value.
