### PR TITLE
nginx/https-redirect: redirect to request domain, ditch regex

### DIFF
--- a/src/configuration/Webservers/nginx/default-hsts
+++ b/src/configuration/Webservers/nginx/default-hsts
@@ -26,7 +26,7 @@ server {
 
 	# Make site accessible from http://localhost/
 	server_name localhost;
-	rewrite        ^ https://$server_name$request_uri? permanent;
+	return 301 https://$host$request_uri;
 }
 
 


### PR DESCRIPTION
- no regex needed here, hence use return instead of rewrite
- use $host instead of $server_name to redirect to requested (sub) domain
