### PR TITLE
Modifying `\pdfmapfile' modifiers to not issue warnings on duplicate font map entries anymore.

### DIFF
--- a/src/common/system.tex
+++ b/src/common/system.tex
@@ -36,8 +36,8 @@
 %
 % Activate font maps
 %
-\pdfmapfile{+SourceCodePro.map}
-\pdfmapfile{+opensans.map}
+\pdfmapfile{=SourceCodePro.map}
+\pdfmapfile{=opensans.map}
 % Packages for fonts
 %\usepackage[variablett]{lmodern}
 \usepackage[scaled=.9]{sourcecodepro}


### PR DESCRIPTION
When tried to compile the document on a Windows machine using latest MiKTeX and recent versions of all LaTeX packages included in the full installation, one can notice around 150 warnings thrown because the `system.tex` file contains two lines to include the font map files of `SourceCodePro` and `opensans` using the `\pdfmapfile` command. Because the `+` modifier is used, warnings are thrown for each font map which is already included by default for the document.

IMHO it is better to use the `=` modifier, which changes the behavior a little bit: The `+` modifier reads the specified font map and ignores all duplicate font map entries (a warning is issued), while the `=` modifier reads the specified font map and replaces matching font map entries with the new entries (no warning issued). I think this is the desired behavior.

For additional information refer to the PDFTeX documentation (`pdftex-a.pdf`, r655 as of November 23, 2010) on pages 24 et seq.