### PR TITLE
Adding `/src/configfiles.txt` to ignore list.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ old
 old/*
 foo
 src/foosrc/missfont.log
+/src/configfiles.txt


### PR DESCRIPTION
The `/src/common/configfiles.tex` file creates the file `/src/configfiles.txt` during compilation, which is an auxiliary file containing all config files used/existing (I am not sure). However, this file should not be committed to the repository, at it is an auxiliary file created during compilation.