### PR TITLE
HSTS Apache: Header always add/set

### DIFF
--- a/src/configuration/Webservers-legacy/Apache/000-default-ssl
+++ b/src/configuration/Webservers-legacy/Apache/000-default-ssl
@@ -177,7 +177,7 @@ SSLStrictSNIVHostCheck off
 	SSLHonorCipherOrder On
 	SSLCompression off
 	# Add six earth month HSTS header for all users...
-	Header add Strict-Transport-Security "max-age=15768000"
+	Header always set Strict-Transport-Security "max-age=15768000"
 	# If you want to protect all subdomains, use the following header
 	# ALL subdomains HAVE TO support HTTPS if you use this!
 	# Strict-Transport-Security: max-age=15768000 ; includeSubDomains


### PR DESCRIPTION
Add "always" as Redirections and "Forbidden" pages should also get HSTS:
https://httpd.apache.org/docs/2.4/mod/mod_headers.html

Replace "add" by "set" to prevent adding a second HSTS field: "If an STS
header field is included, the HSTS Host MUST include only one such
header field." https://tools.ietf.org/html/rfc6797#section-7.1
