### PR TITLE
Add certificate chain files to configs of apache and lighttpd

### DIFF
--- a/src/configuration/Webservers/lighttpd/10-ssl.conf
+++ b/src/configuration/Webservers/lighttpd/10-ssl.conf
@@ -5,6 +5,7 @@ $SERVER["socket"] == "0.0.0.0:443" {
 	ssl.use-sslv2 = "disable"
 	ssl.use-sslv3 = "disable"
 	ssl.pemfile = "/etc/lighttpd/server.pem"
+	ssl.ca-file = "/etc/ssl/certs/server.crt"
 
 	ssl.cipher-list = "EDH+CAMELLIA:EDH+aRSA:EECDH+aRSA+AESGCM:EECDH+aRSA+SHA384:EECDH+aRSA+SHA256:EECDH:+CAMELLIA256:+AES256:+CAMELLIA128:+AES128:+SSLv3:!aNULL!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!DSS:!RC4:!SEED:!ECDSA:CAMELLIA256-SHA:AES256-SHA:CAMELLIA128-SHA:AES128-SHA"
 	ssl.honor-cipher-order = "enable"
@@ -12,3 +13,4 @@ $SERVER["socket"] == "0.0.0.0:443" {
 	# use this only if all subdomains support HTTPS!
 	# setenv.add-response-header  = ( "Strict-Transport-Security" => "max-age=15768000; includeSubDomains")
 }
+

--- a/src/practical_settings/webserver.tex
+++ b/src/practical_settings/webserver.tex
@@ -14,7 +14,7 @@ synonyms~\footnote{https://www.mail-archive.com/openssl-dev@openssl.org/msg33405
 \subsubsection{Settings}
 Enabled modules \emph{SSL} and \emph{Headers} are required.
 
-\configfile{default-ssl}{162-170}{SSL configuration for an Apache vhost}
+\configfile{default-ssl}{42-43,52-52,62-62,162-170}{SSL configuration for an Apache vhost}
 
 \subsubsection{Additional settings}
 You might want to redirect everything to \emph{https://} if possible. In Apache
@@ -46,7 +46,7 @@ See appendix \ref{cha:tools}
 
 
 \subsubsection{Settings}
-\configfile{10-ssl.conf}{3-14}{SSL configuration for lighttpd}
+\configfile{10-ssl.conf}{3-15}{SSL configuration for lighttpd}
 
 Starting with lighttpd version 1.4.29 Diffie-Hellman and Elliptic-Curve Diffie-Hellman key agreement protocols are supported.
 By default, elliptic curve "prime256v1" (also "secp256r1") will be used, if no other is given.


### PR DESCRIPTION
AFAIK this is needed for compability with all clients.

For nginx, this is not needed, accoring to the docs.

Also, in lighty, if the `ca-file` is not given, but are only in the pem, the intermediate and root certs are marked as Extra download. Some common browsers on some platforms are marking such websites as not not trustworthy, that's how I found these config options.