### PR TITLE
Corrected the link for the SSL Labs Best Practices Guide

### DIFF
--- a/src/tools.tex
+++ b/src/tools.tex
@@ -55,5 +55,5 @@ Command line tools
 
 \section{Guides}
 \begin{itemize*}
-  \item See: \url{https://www.ssllabs.com/downloads/SSL_TLS_Deployment_Best_Practices_1.3.pdf}.
+  \item See: \url{https://www.ssllabs.com/downloads/SSL_TLS_Deployment_Best_Practices.pdf}.
 \end{itemize*}


### PR DESCRIPTION
The link to the best practices guide in the tools chapter section was wrong (404). Changed it to a working one. Maybe it would be better to link to the entry page for the guide (https://www.ssllabs.com/projects/best-practices/index.html) instead of the pdf itself in case its name changes again?

Regards

Jens