### PR TITLE
Disabled SSLv3 for security level may

### DIFF
--- a/src/configuration/MailServers/Postfix/main.cf
+++ b/src/configuration/MailServers/Postfix/main.cf
@@ -32,7 +32,10 @@ smtp_tls_loglevel = 1
 smtpd_tls_auth_only = yes
 tls_ssl_options = NO_COMPRESSION
 
-smtpd_tls_mandatory_protocols = !SSLv2, !SSLv3
+smtpd_tls_mandatory_protocols=!SSLv2,!SSLv3
+smtp_tls_mandatory_protocols=!SSLv2,!SSLv3
+smtpd_tls_protocols=!SSLv2,!SSLv3
+smtp_tls_protocols=!SSLv2,!SSLv3
 smtpd_tls_mandatory_ciphers=high
 tls_high_cipherlist=EDH+CAMELLIA:EDH+aRSA:EECDH+aRSA+AESGCM:EECDH+aRSA+SHA384:EECDH+aRSA+SHA256:EECDH:+CAMELLIA256:+AES256:+CAMELLIA128:+AES128:+SSLv3:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!DSS:!RC4:!SEED:!ECDSA:CAMELLIA256-SHA:AES256-SHA:CAMELLIA128-SHA:AES128-SHA
 smtpd_tls_eecdh_grade=ultra


### PR DESCRIPTION
The recommended settings for postfix contain the following options:
>smtpd_tls_security_level = may
>smtp_tls_security_level = may
>smtpd_tls_mandatory_protocols = !SSLv2, !SSLv3

To my understanding this would leave SSLv3 enabled, both for sending and receiving mail. According to Postfix' [TLS manual](http://www.postfix.org/TLS_README.html) there are two different configuration methods for TLS-ciphers (Which I found a bit confusing ..):

* smtpd_tls_mandatory_protocols - if smtpd_tls_security_level is set to 'encrypt', those settings apply
* smtpd_tls_protocols - if smtpd_tls_security_level is set to 'may', those settings apply
* smtp_tls_mandatory_protocols - if smtp_tls_security_level is set to 'encrypt', those settings apply
* smtp_tls_protocols - if smtp_tls_security_level is set to 'may', those settings apply

This commit fixes this gap to my understanding (I'm not an expert, neither for Postfix nor when it comes to cryptography. I'm just somebody who was mistakenly given administrative privileges.).


//Edit: I'm not 100% correct. With:

>smtpd_tls_security_level = may
>smtp_tls_security_level = may

only:

>smtpd_tls_protocols=!SSLv2,!SSLv3
>smtp_tls_protocols=!SSLv2,!SSLv3

would be necessary.