### PR TITLE
Constrain figure positions by FloatBarrier

### DIFF
--- a/src/practical_settings/vpn.tex
+++ b/src/practical_settings/vpn.tex
@@ -195,6 +195,8 @@ Please note that these settings restrict the available algorithms for
 
 %% cipherstrings current 2013-12-09
 % ---------------------------------------------------------------------- 
+\FloatBarrier % the preceding section has several figures. Floating them too far away might get confusing for readers.
+
 \subsection{OpenVPN}
 
 \subsubsection{Tested with Versions}

--- a/src/practical_settings/webserver.tex
+++ b/src/practical_settings/webserver.tex
@@ -343,6 +343,7 @@ Set-WebConfiguration -Location "$WebSiteName/$WebApplicationName" `
 \subsubsection{How to test}
 See appendix \ref{cha:tools}
 
+\FloatBarrier % the preceding section has several figures. Floating them too far away might get confusing for readers.
 %%----------------------------------------------------------------------
 
 %%% Local Variables:


### PR DESCRIPTION
Some figures from the Webserver and VPN sections are placed far away from their respective references by LaTeX. Adding \FloatBarriers increases readability because the reader doesn't need to "hunt down" figures.