### PR TITLE
Always log Postfix TLS connections

### DIFF
--- a/src/configuration/MailServers/Postfix/main.cf
+++ b/src/configuration/MailServers/Postfix/main.cf
@@ -20,12 +20,12 @@ readme_directory = no
 # TLS parameters
 smtpd_tls_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
 smtpd_tls_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
-# use 0 for Postfix >= 2.9, and 1 for earlier versions
-smtpd_tls_loglevel = 0
+# log TLS connection info
+smtpd_tls_loglevel = 1
+smtp_tls_loglevel = 1
 # enable opportunistic TLS support in the SMTP server and client
 smtpd_tls_security_level = may
 smtp_tls_security_level = may
-smtp_tls_loglevel = 1
 # if you have authentication enabled, only offer it after STARTTLS
 smtpd_tls_auth_only = yes
 tls_ssl_options = NO_COMPRESSION

--- a/src/configuration/MailServers/Postfix/main.cf
+++ b/src/configuration/MailServers/Postfix/main.cf
@@ -17,8 +17,6 @@ append_dot_mydomain = no
 
 readme_directory = no
 
-readme_directory = no
-
 # TLS parameters
 smtpd_tls_cert_file=/etc/ssl/certs/ssl-cert-snakeoil.pem
 smtpd_tls_key_file=/etc/ssl/private/ssl-cert-snakeoil.key
@@ -52,9 +50,8 @@ smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
 # See /usr/share/doc/postfix/TLS_README.gz in the postfix-doc package for
 # information on enabling SSL in the smtp client.
 
-myhostname = 
+myhostname =
+mydestination =
 alias_maps = hash:/etc/aliases
 alias_database = hash:/etc/aliases
-myorigin = /etc/mailname
-mydestination = 
 

--- a/src/practical_settings/mailserver.tex
+++ b/src/practical_settings/mailserver.tex
@@ -241,14 +241,14 @@ encryption we do not restrict the list of ciphers or protocols for communication
 with other mail servers to avoid transmission in plain text. There are still
 some steps needed to enable TLS, all in \verb|main.cf|:
 
-\configfile{main.cf}{22-33}{Opportunistic TLS in Postfix}
+\configfile{main.cf}{20-31}{Opportunistic TLS in Postfix}
 
 \paragraph{MSA:}
 For the MSA \verb|smtpd| process which communicates with mail clients, we first
 define the ciphers that are acceptable for the ``mandatory'' security level,
 again in \verb|main.cf|:
 
-\configfile{main.cf}{36-46}{MSA TLS configuration in Postfix}
+\configfile{main.cf}{34-44}{MSA TLS configuration in Postfix}
 
 Then, we configure the MSA smtpd in \verb|master.cf| with two
 additional options that are only used for this instance of smtpd:
@@ -256,7 +256,7 @@ additional options that are only used for this instance of smtpd:
 \configfile{master.cf}{12-14}{MSA smtpd service configuration in Postfix}
 
 For those users who want to use EECDH key exchange, it is possible to customize this via:
-\configfile{main.cf}{47-47}{EECDH customization in Postfix}
+\configfile{main.cf}{45-45}{EECDH customization in Postfix}
 The default value since Postfix 2.8 is ``strong''.
 
 \subsubsection{Limitations}


### PR DESCRIPTION
As described on the mailing list, this causes Postfix to always log TLS connection info.  Previously this was recommended only for pre 2.9 versions.