### PR TITLE
Minor fixes for FAQ.md

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -3,14 +3,14 @@
 
 Q: I want to review the document. What do I need to do?
 
-A: `git clone` the document, make changes, send us a diff
+A: `git clone` the document, make changes, send us a diff.
 Do not forget to add your name to `src/acknowledgements.tex`!
 
 
 
 Q: Who is invited to review the document?
 
-A: Essentially everyone. The core group of editors consists of crypologists,
+A: Essentially everyone. The core group of editors consists of cryptologists,
 computer scientists and sysadmins.
 
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -36,5 +36,5 @@ A: Please get in contact with us on the mailing list!
 
 Q: Is there a webpage?
 
-A: yes, bettercrypto.org
+A: yes, https://bettercrypto.org
 


### PR DESCRIPTION
A typo fix, one missing full stop and `https://` prefix for bettercrypto.org so it matches the other URLs in the file.

Hope you're having a great day! :)