### PR TITLE
Generate OpenSSH compatible moduli from IKE DH groups

### DIFF
--- a/tools/dhparams/Makefile
+++ b/tools/dhparams/Makefile
@@ -1,9 +1,22 @@
 INFILES = $(wildcard *.txt)
-OUTFILES = $(patsubst %.txt, %.pem, $(INFILES))
+PEMFILES = $(patsubst %.txt, %.pem, $(INFILES))
+OPENSSHFILES = $(patsubst %.txt, %.openssh, $(INFILES))
+OUTFILES = $(PEMFILES) $(OPENSSHFILES) moduli.openssh
 
 .DELETE_ON_ERROR:
+
+.PHONY: all clean
 
 all: $(OUTFILES)
 
 %.pem: %.txt
 	gen_pkcs3 `perl parse.pl $<` > $@
+
+%.openssh: %.txt
+	sh openssh-modulus.sh $< > $@
+
+moduli.openssh: $(OPENSSHFILES)
+	cat $^ > $@
+
+clean:
+	rm -f $(OUTFILES)

--- a/tools/dhparams/README
+++ b/tools/dhparams/README
@@ -1,8 +1,10 @@
-Tools to convert the RFC-defined IKE DH groups into OpenSSL compatible
-PEM files that we can distribute.
+Tools to convert the RFC-defined IKE DH groups into OpenSSL and OpenSSH
+compatible PEM and moduli files that we can distribute.
 
-The files in this directory have been generated (as described below)
-from the RFCs and compared with the ones in Exim's "std-crypto.c".
+The files in this directory have been generated (as described below) from the
+RFCs.  The PEM files have been compared with the ones in Exim's
+"std-crypto.c".  The OpenSSH moduli files have been checked using `ssh-keygen`
+with the `-T` option.
 
 Prerequisite: gen_pkcs3 from the Exim sources, which we don't include
 here due to duplication and licensing issues (ACH is under CC, Exim
@@ -36,4 +38,4 @@ Works as follows:
 
 - run "make" (and make sure gen_pkcs3 is in $PATH)
 
-- collect <group>.pem files
+- collect <group>.pem files, moduli.openssh file

--- a/tools/dhparams/openssh-modulus.sh
+++ b/tools/dhparams/openssh-modulus.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+rfc3526_file="$1"
+
+modulus=$(sed -ne "s/[\t ]*\\([0-9A-F]\{8\}\\)/\\1/gip" $rfc3526_file | paste -s -d '')
+generator=$(sed -ne "s/.*The generator is:[\t ]*\\([0-9]*\\).*/\\1/gp" $rfc3526_file)
+size=$((${#modulus} * 4 - 1))
+
+printf "20030301000000 2 6 500 $size $generator $modulus\n"


### PR DESCRIPTION
ECRYPT II (and consequently this guide) recommends using Diffie-Hellman
groups as defined in RFC 3526 if DH parameters are configurable.  Unlike
PEM files, no OpenSSH comparatible moduli file is provided by the
tools.  This adds a simple script and the necessary Makefile rules to
generate a moduli file from txt files.
