### PR TITLE
substitute unsafe with safe curve option

### DIFF
--- a/src/configuration/Proxies/stunnel/stunnel.conf
+++ b/src/configuration/Proxies/stunnel/stunnel.conf
@@ -47,7 +47,7 @@ key = /etc/ssl/private/ssl-cert-snakeoil.key
 
 ciphers = EDH+CAMELLIA:EDH+aRSA:EECDH+aRSA+AESGCM:EECDH+aRSA+SHA384:EECDH+aRSA+SHA256:EECDH:+CAMELLIA256:+AES256:+CAMELLIA128:+AES128:+SSLv3:!aNULL!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!DSS:!RC4:!SEED:!ECDSA:CAMELLIA256-SHA:AES256-SHA:CAMELLIA128-SHA:AES128-SHA
 
-curve = secp384r1
+curve = secp521r1 
 options = NO_SSLv2
 options = NO_SSLv3
 options = cipher_server_preference


### PR DESCRIPTION
curve secp384r1 (P-384) is not considered safe (see https://safecurves.cr.yp.to/ ) while P-521 should be safe.
