### PR TITLE
Add quotation mark in add_header HSTS directive

### DIFF
--- a/src/configuration/Webservers/nginx/default
+++ b/src/configuration/Webservers/nginx/default
@@ -113,7 +113,7 @@ server {
 	ssl_prefer_server_ciphers on;
 	ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # not possible to do exclusive
 	ssl_ciphers 'EDH+CAMELLIA:EDH+aRSA:EECDH+aRSA+AESGCM:EECDH+aRSA+SHA256:EECDH:+CAMELLIA128:+AES128:+SSLv3:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!DSS:!RC4:!SEED:!IDEA:!ECDSA:kEDH:CAMELLIA128-SHA:AES128-SHA';
-	add_header Strict-Transport-Security max-age=15768000; # six months
+	add_header Strict-Transport-Security "max-age=15768000"; # six months
 	# use this only if all subdomains support HTTPS!
 	# add_header Strict-Transport-Security "max-age=15768000; includeSubDomains";
 

--- a/src/configuration/Webservers/nginx/default-ec
+++ b/src/configuration/Webservers/nginx/default-ec
@@ -113,7 +113,7 @@ server {
 	ssl_prefer_server_ciphers on;
 	ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # not possible to do exclusive
 	ssl_ciphers 'EDH+CAMELLIA:EDH+aRSA:EECDH+aRSA+AESGCM:EECDH+aRSA+SHA256:EECDH:+CAMELLIA128:+AES128:+SSLv3:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!DSS:!RC4:!SEED:!IDEA:!ECDSA:kEDH:CAMELLIA128-SHA:AES128-SHA';
-	add_header Strict-Transport-Security max-age=15768000; # six months
+	add_header Strict-Transport-Security "max-age=15768000"; # six months
 	# use this only if all subdomains support HTTPS!
 	# add_header Strict-Transport-Security "max-age=15768000; includeSubDomains";
 	ssl_ecdh_curve secp384r1;

--- a/src/configuration/Webservers/nginx/default-hsts
+++ b/src/configuration/Webservers/nginx/default-hsts
@@ -63,7 +63,7 @@ server {
 	ssl_prefer_server_ciphers on;
 	ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # not possible to do exclusive
 	ssl_ciphers 'EDH+CAMELLIA:EDH+aRSA:EECDH+aRSA+AESGCM:EECDH+aRSA+SHA256:EECDH:+CAMELLIA128:+AES128:+SSLv3:!aNULL:!eNULL:!LOW:!3DES:!MD5:!EXP:!PSK:!DSS:!RC4:!SEED:!IDEA:!ECDSA:kEDH:CAMELLIA128-SHA:AES128-SHA';
-	add_header Strict-Transport-Security max-age=15768000; # six months
+	add_header Strict-Transport-Security "max-age=15768000"; # six months
 	# use this only if all subdomains support HTTPS!
 	# add_header Strict-Transport-Security "max-age=15768000; includeSubDomains";
 


### PR DESCRIPTION
Nginx http header values need quotation mark to take effects. See https://nginx.org/en/docs/http/ngx_http_headers_module.html