### PR TITLE
fixed expire parameter

### DIFF
--- a/src/configuration/GPG/GnuPG/params.txt
+++ b/src/configuration/GPG/GnuPG/params.txt
@@ -5,7 +5,7 @@ Subkey-Length: 4096
 Name-Real: <your-name>
 Name-Email: <your-email-address>
 Passphrase: <password>
-Expires: 2y
+Expire-Date: 2y
 # My preferences: AES256, CAMELLIA256, AES192, CAMELLIA192, AES128, CAMELLIA128, TWOFISH, SHA512, SHA384, SHA256, BZIP2, ZLIB and ZIP
 Preferences: S9 S13 S8 S12 S7 S11 S10 H10 H9 H8 Z3 Z2 Z1 
 %commit


### PR DESCRIPTION
using gpg 2.2.32 I get the following error using this configuration:

```
$ gpg --batch --full-gen-key ./params.txt
gpg: ./params.txt:8: unknown keyword
```

The correct parameter to set the expiration date would be `Expire-Date`, not `Expires`.  cf. [Unattended key generation](https://www.gnupg.org/documentation/manuals/gnupg/Unattended-GPG-key-generation.html).